### PR TITLE
Extended buildings percept closes #14 \ Rampestampers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ hs_err_pid*
 .idea/*
 tygron_environment.iml
 /.settings/
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
-- java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $TYGRONPWD $TYGRONMAIL
+- java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script: 
+- java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $TYGRONPWD $TYGRONMAIL
+- mvn test
+jdk:
+- oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Tygron EIS connector fork by 'De RAMpestampers'
-[![Build Status](https://travis-ci.org/spiderbiggen/tygron.svg?branch=develop)](https://travis-ci.org/spiderbiggen/tygron)
+# Tygron EIS connector
 
 Tygron is an EIS environment that connects with the tygron http://www.tygron.com system for urban planning.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Tygron EIS connector
+# Tygron EIS connector fork by 'De RAMpestampers'
+[![Build Status](https://travis-ci.org/spiderbiggen/tygron.svg?branch=develop)](https://travis-ci.org/spiderbiggen/tygron)
 
 Tygron is an EIS environment that connects with the tygron http://www.tygron.com system for urban planning.
 

--- a/environment/src/main/java/tygronenv/EntityEventHandler.java
+++ b/environment/src/main/java/tygronenv/EntityEventHandler.java
@@ -22,6 +22,7 @@ import nl.tytech.data.engine.item.Building;
 import nl.tytech.data.engine.item.Function;
 import nl.tytech.data.engine.item.Setting;
 import nl.tytech.data.engine.item.Stakeholder;
+import tygronenv.translators.J2ExtBuilding;
 
 /**
  * Listen to entity events and store them till they are needed. Thread safe
@@ -94,6 +95,7 @@ public class EntityEventHandler implements EventListenerInterface {
 				break;
 			case BUILDINGS:
 				createPercepts(event.<ItemMap<Building>> getContent(MapLink.COMPLETE_COLLECTION), type);
+				createExtPercepts(event.<ItemMap<J2ExtBuilding.ExtBuilding>> getContent(MapLink.COMPLETE_COLLECTION), type);
 				break;
 			case SETTINGS:
 				createPercepts(event.<ItemMap<Setting>> getContent(MapLink.COMPLETE_COLLECTION), type);
@@ -109,6 +111,32 @@ public class EntityEventHandler implements EventListenerInterface {
 		}
 	}
 
+    /**
+     * Create percepts contained in a ClientItemMap array and add them to the
+     * {@link #collectedPercepts}.
+     *
+     * @param itemMap
+     *            list of ClientItemMap elements.
+     * @param type
+     *            the type of elements in the map.
+     */
+    private <T extends Item> void createExtPercepts(ItemMap<T> itemMap, EventTypeEnum type) {
+        ArrayList<T> items = new ArrayList<T>(itemMap.values());
+        List<Percept> percepts = new ArrayList<Percept>();
+        Parameter[] parameters = null;
+        try {
+            parameters = translator.translate2Parameter(items);
+        } catch (TranslationException e) {
+            e.printStackTrace();
+        }
+        if (parameters != null) {
+            Percept p = new Percept("extended" + type.name().toLowerCase(), parameters);
+            percepts.add(p);
+        }
+        addPercepts(type, percepts);
+
+    }
+
 	/**
 	 * Create percepts contained in a ClientItemMap array and add them to the
 	 * {@link #collectedPercepts}.
@@ -118,7 +146,6 @@ public class EntityEventHandler implements EventListenerInterface {
 	 * @param type
 	 *            the type of elements in the map.
 	 */
-
 	private <T extends Item> void createPercepts(ItemMap<T> itemMap, EventTypeEnum type) {
 		ArrayList<T> items = new ArrayList<T>(itemMap.values());
 		List<Percept> percepts = new ArrayList<Percept>();

--- a/environment/src/main/java/tygronenv/EntityEventHandler.java
+++ b/environment/src/main/java/tygronenv/EntityEventHandler.java
@@ -115,8 +115,10 @@ public class EntityEventHandler implements EventListenerInterface {
      * Create percepts pertaining to buildings contained in a ClientItemMap array and add them to the
      * {@link #collectedPercepts}.
      *
-     * @param event
-     *            The event that was updated.
+	 * @param itemMap
+	 *            list of ClientItemMap elements.
+	 * @param type
+	 *            the type of elements in the map.
      */
     private <T extends Building> void createBuildingPercepts(ItemMap<T> itemMap, EventTypeEnum type) {
 
@@ -126,16 +128,17 @@ public class EntityEventHandler implements EventListenerInterface {
             percepts.add(createBuildingPercept(new ArrayList<>(itemMap.values()), typeString));
         } catch (TranslationException e) {
             e.printStackTrace();
-            percepts.add(new Percept(typeString));
         }
+        String extTypeString = "ext" + typeString;
         try {
+            // Set translator to the extended building translator to get more info in the percept
             translator.registerJava2ParameterTranslator(new J2ExtBuilding());
-            percepts.add(createBuildingPercept(new ArrayList<>(itemMap.values()), "extended" + typeString));
-            translator.registerJava2ParameterTranslator(new J2Building());
+            percepts.add(createBuildingPercept(new ArrayList<>(itemMap.values()), extTypeString));
         } catch (TranslationException e) {
             e.printStackTrace();
-            percepts.add(new Percept("extended" + typeString));
         }
+        // Reset translator to use the standard building translator.
+        translator.registerJava2ParameterTranslator(new J2Building());
         addPercepts(type, percepts);
     }
 
@@ -143,8 +146,8 @@ public class EntityEventHandler implements EventListenerInterface {
      * Method to create A Building percept based on the given \<T\>
      * @param items all items that should be put in the percept
      * @param type Lowercase string representation of the event type
-     * @param <T>
-     * @return
+     * @param <T> The type of the items in the list. Should extend {@link Building}
+     * @return a new {@link Percept} containing all the info from The items
      * @throws TranslationException
      */
     private <T extends Building> Percept createBuildingPercept(List<T> items, String type) throws TranslationException {

--- a/environment/src/main/java/tygronenv/translators/J2ExtBuilding.java
+++ b/environment/src/main/java/tygronenv/translators/J2ExtBuilding.java
@@ -21,7 +21,7 @@ public class J2ExtBuilding implements Java2Parameter<Building> {
 
     @Override
     public Parameter[] translate(Building b) throws TranslationException {
-        return new Parameter[] { new Function("building", new Numeral(b.getID()), new Identifier(b.getName()),
+        return new Parameter[] { new Function("extendedbuilding", new Numeral(b.getID()), new Identifier(b.getName()),
                 translator.translate2Parameter(b.getCategories())[0],
                 new Numeral(b.getFloors())),
                 new Numeral(b.getOwnerID()),
@@ -31,9 +31,7 @@ public class J2ExtBuilding implements Java2Parameter<Building> {
 
     @Override
     public Class<? extends Building> translatesFrom() {
-        return ExtBuilding.class;
+        return Building.class;
     }
 
-    public class ExtBuilding extends Building {
-    }
 }

--- a/environment/src/main/java/tygronenv/translators/J2ExtBuilding.java
+++ b/environment/src/main/java/tygronenv/translators/J2ExtBuilding.java
@@ -1,0 +1,39 @@
+package tygronenv.translators;
+
+import eis.eis2java.exception.TranslationException;
+import eis.eis2java.translation.Java2Parameter;
+import eis.eis2java.translation.Translator;
+import eis.iilang.Function;
+import eis.iilang.Identifier;
+import eis.iilang.Numeral;
+import eis.iilang.Parameter;
+import nl.tytech.data.engine.item.Building;
+
+/**
+ * Translate {@link Building} into building(ID, name, [categories], floors, stakeHolderId, ConstYear).
+ *
+ * @author S. Breetveld
+ *
+ */
+public class J2ExtBuilding implements Java2Parameter<Building> {
+
+    private final Translator translator = Translator.getInstance();
+
+    @Override
+    public Parameter[] translate(Building b) throws TranslationException {
+        return new Parameter[] { new Function("building", new Numeral(b.getID()), new Identifier(b.getName()),
+                translator.translate2Parameter(b.getCategories())[0],
+                new Numeral(b.getFloors())),
+                new Numeral(b.getOwnerID()),
+                new Numeral(b.getConstructionYear())
+        };
+    }
+
+    @Override
+    public Class<? extends Building> translatesFrom() {
+        return ExtBuilding.class;
+    }
+
+    public class ExtBuilding extends Building {
+    }
+}

--- a/environment/src/main/java/tygronenv/translators/J2ExtBuilding.java
+++ b/environment/src/main/java/tygronenv/translators/J2ExtBuilding.java
@@ -21,7 +21,7 @@ public class J2ExtBuilding implements Java2Parameter<Building> {
 
     @Override
     public Parameter[] translate(Building b) throws TranslationException {
-        return new Parameter[] { new Function("extendedbuilding", new Numeral(b.getID()), new Identifier(b.getName()),
+        return new Parameter[] { new Function("extbuilding", new Numeral(b.getID()), new Identifier(b.getName()),
                 translator.translate2Parameter(b.getCategories())[0],
                 new Numeral(b.getFloors())),
                 new Numeral(b.getOwnerID()),


### PR DESCRIPTION
this percept will return all buildings in the same way building does while adding some extra numerals.

call `percept(extbuildings(X))` to get the list and then 
each building in the list consists of 6 elements

the elements appear in this order
- object id
- building name
- categories
- number of floors
- Owner Stakeholder ID
- construction year
