### PR TITLE
End easy modus for checkstyle validation on Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 # test checkstyle only on changed lines using this python script
 - git diff upstream/context...HEAD -U0 -- *.java --minimal | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 # checkstyle check is configured with these arguments
-- mvn checkstyle:check -Dcheckstyle.config.location="$PWD/sun_checks_custom.xml" -Dcheckstyle.suppressions.location="$PWD/suppressions.xml" -Dcheckstyle.suppressions.file.expression=checkstyle.supression.file
+- mvn checkstyle:check -Dcheckstyle.config.location="$TRAVIS_BUILD_DIR/sun_checks_custom.xml" -Dcheckstyle.suppressions.location="$TRAVIS_BUILD_DIR/suppressions.xml" -Dcheckstyle.suppressions.file.expression=checkstyle.suppression.file
 #check pmd and checkstyle only for environment
 - cd environment
 - mvn pmd:pmd

--- a/checkstylediff.py
+++ b/checkstylediff.py
@@ -95,7 +95,7 @@ for root, dirs, files in os.walk("./"):
 		if file.endswith(".java"):
 			java_files.append(os.path.join(root, file))
 # make the file names the same convention as the files read in git diff
-java_files = [x.replace("./","").replace("\\","[\\\/]") for x in java_files]
+java_files = [x.replace("./","").replace("\\","[\\\/]").replace("/","[\\\/]") for x in java_files]
 # all files that are not changed can be fully suppressed and have no changes
 suppressed_files = [(file,False) for file in [y for y in java_files] if not(file in [y[0] for y in changed_files])]
 

--- a/sun_checks_custom.xml
+++ b/sun_checks_custom.xml
@@ -44,7 +44,8 @@
 
     <!-- Checks that a package-info.java file exists for each package.     -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
-    <module name="JavadocPackage"/>
+    <!-- Not in line with the rest of the code -->
+    <!--<module name="JavadocPackage"/> -->
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
@@ -86,7 +87,9 @@
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod"/>
         <module name="JavadocType"/>
-        <module name="JavadocVariable"/>
+        <!-- Ommit this check because it is not in line with the rest of the code
+        to do javadoc Variables and additionaly it would be pretty exhaustive to use this-->
+        <!-- <module name="JavadocVariable"/> -->
         <module name="JavadocStyle"/>
 
         <!-- Checks for Naming Conventions.                  -->
@@ -112,7 +115,9 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength"/>
+        <module name="LineLength">
+        	<property name="max" value="120"/>
+	</module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 
@@ -157,7 +162,9 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="DesignForExtension"/>
+        <!--  DesignforExtension won't be used because it enforces a coding 
+        style we do not necessarily want to enforce -->
+        <!--<module name="DesignForExtension"/> -->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>


### PR DESCRIPTION
I noticed people not complaining about checkstyle yet. And I found that in the Travis environment (linux) checkstyle always passes. This merge fixes this to really allow for all lines changed in the PR compared to the context branch to be checkstyled (and the build failing if a checkstyle finds something).

Fixed by taking into account a different way to adress directories in the checkstylediff script. Also for clarification used the Travis_work_dir variables instead of PWD for working directory.

We're not getting off that easy :smile: 
