### PR TITLE
Checkstyle fix to circumvent erronous jython behaviour.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 # test the code
 - mvn test -Dcobertura.skip
+# put the last commit of the context branch in a file to be read later
+- git rev-parse upstream/context > fallbackcommit.txt
 # test checkstyle only on changed lines using this python script
 # get the latest commit of legacy contributers on branch
 # take the latest commit of the legacy contributors

--- a/get_last_legacy_commit.py
+++ b/get_last_legacy_commit.py
@@ -8,13 +8,17 @@ import re
 import subprocess
 
 LEGACY_CODERS_CONFIG_FILE = "legacycoders.cfg"
-BRANCH_TO_MERGE_TO = "upstream/context"
+FALLBACK_COMMIT_TXT = "fallbackcommit.txt"
+
+fallback_commit = ""
+with open(FALLBACK_COMMIT_TXT) as f:
+	fallback_commit = f.readlines()[0]
 
 legacy_coders = []
 with open(LEGACY_CODERS_CONFIG_FILE) as f:
 	legacy_coders = f.readlines()
 
-latest_legacy_commit = subprocess.Popen("git rev-parse "+BRANCH_TO_MERGE_TO, stdout=subprocess.PIPE).stdout.read().replace("\n","")
+latest_legacy_commit = fallback_commit
 legacy_coder_found = False
 
 for line in sys.stdin:

--- a/get_second_entry.py
+++ b/get_second_entry.py
@@ -1,5 +1,0 @@
-# rudimentary program to get the second
-# value of a spaces seperated file
-
-import sys
-print(sys.argv[2])


### PR DESCRIPTION
Jython showed erronous behaviour when running a console command
through the subprocess module. Instead of running this command through
the script, it is run before hand and written to a file which the program
can then read.

Fixes checkstyle giving a passing indication while there are still
checkstyle errors.

Also deleted left over code (get_second_entry.py)
