### PR TITLE
Actionlog percept implemented and powermockito added

### DIFF
--- a/.scope.yml
+++ b/.scope.yml
@@ -1,0 +1,4 @@
+component_deph: 1
+languages:
+- python
+- java

--- a/.scope.yml
+++ b/.scope.yml
@@ -1,4 +1,4 @@
-component_deph: 1
+component_depth: 1
 languages:
 - python
 - java

--- a/.scope.yml
+++ b/.scope.yml
@@ -1,4 +1,0 @@
-component_depth: 1
-languages:
-- python
-- java

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -8,6 +8,7 @@
 		<!-- name of the main project on eishub. -->
 		<environmentname>tygron</environmentname>
 		<mainclass>tygronenv.EisEnv</mainclass>
+		<powermock.version>1.6.5</powermock.version>
 	</properties>
 
 	<groupId>eishub</groupId>
@@ -55,7 +56,7 @@
 			<url>https://raw.github.com/eishub/mvn-repo/master</url>
 		</repository>
 	</repositories>
-
+    
 	<dependencies>
 		<dependency>
 			<groupId>nl.tygron</groupId>
@@ -74,6 +75,20 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- http://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
+		<dependency>
+		    <groupId>org.powermock</groupId>
+		    <artifactId>powermock-module-junit4</artifactId>
+		    <version>1.6.5</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		  <groupId>org.powermock</groupId>
+		  <artifactId>powermock-api-mockito</artifactId>
+		  <version>1.6.5</version>
+		  <scope>test</scope>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/environment/src/main/java/tygronenv/translators/J2ActionLog.java
+++ b/environment/src/main/java/tygronenv/translators/J2ActionLog.java
@@ -2,9 +2,11 @@ package tygronenv.translators;
 
 import eis.eis2java.exception.TranslationException;
 import eis.eis2java.translation.Java2Parameter;
+import eis.iilang.Function;
 import eis.iilang.Identifier;
 import eis.iilang.Numeral;
 import eis.iilang.Parameter;
+import eis.iilang.ParameterList;
 import nl.tytech.core.client.event.EventManager;
 import nl.tytech.core.net.serializable.MapLink;
 import nl.tytech.data.engine.item.ActionLog;
@@ -19,17 +21,19 @@ public class J2ActionLog implements Java2Parameter<ActionLog> {
 
 	@Override
 	public Parameter[] translate(ActionLog actionLog) throws TranslationException {
-
+	    
+	    ParameterList parList = new ParameterList();
+	    
 		for (Indicator indicator : EventManager.<Indicator> getItemMap(MapLink.INDICATORS).values()) {
 			Double increase = actionLog.getIncrease(indicator);
 			if (increase != null) {
 				// TODO: Implement how you want to use it, and add to parameter
 				// result
-
+			    parList.add(new ParameterList(new Numeral(indicator.getID()), new Numeral(increase)));
 			}
 		}
 
-		return new Parameter[] { new Identifier(actionLog.getAction()), new Numeral(actionLog.getID()) };
+		return new Parameter[] { new Function("actionlog", new Numeral(actionLog.getStakeholder().getID()), new Identifier(actionLog.getAction()), new Numeral(actionLog.getID()), parList) };
 	}
 
 	@Override

--- a/environment/src/main/java/tygronenv/translators/J2ActionLog.java
+++ b/environment/src/main/java/tygronenv/translators/J2ActionLog.java
@@ -9,33 +9,55 @@ import eis.iilang.Parameter;
 import eis.iilang.ParameterList;
 import nl.tytech.core.client.event.EventManager;
 import nl.tytech.core.net.serializable.MapLink;
+import nl.tytech.core.structure.ItemMap;
 import nl.tytech.data.engine.item.ActionLog;
 import nl.tytech.data.engine.item.Indicator;
+import nl.tytech.data.engine.item.Stakeholder;
 
 /**
+ *Translates {@link ActionLog} into
+ *actionlog(StakeholderID, ActionDescription, ActionLogID, X).
+ *X is a list of (IndicatorID,Increase).
  *
  * @author Frank Baars
  *
  */
 public class J2ActionLog implements Java2Parameter<ActionLog> {
 
+	/**
+	 * Empty constructor.
+	 */
+	public J2ActionLog() {
+	}
+	
+	/**
+	 * Translates the actionlog into a parameter.
+	 */
 	@Override
-	public Parameter[] translate(ActionLog actionLog) throws TranslationException {
+	public Parameter[] translate(final ActionLog actionLog) throws TranslationException {
 	    
 	    ParameterList parList = new ParameterList();
+	    ItemMap<Indicator> map =
+	    		EventManager.<Indicator>getItemMap(MapLink.INDICATORS);
 	    
-		for (Indicator indicator : EventManager.<Indicator> getItemMap(MapLink.INDICATORS).values()) {
+		for (Indicator indicator : map.values()) {
 			Double increase = actionLog.getIncrease(indicator);
-			if (increase != null) {
-				// TODO: Implement how you want to use it, and add to parameter
-				// result
-			    parList.add(new ParameterList(new Numeral(indicator.getID()), new Numeral(increase)));
+			if (increase != null && increase != 0.0) {
+			    parList.add(new ParameterList(new Numeral(indicator.getID()),
+			    		new Numeral(increase)));
 			}
 		}
 
-		return new Parameter[] { new Function("actionlog", new Numeral(actionLog.getStakeholder().getID()), new Identifier(actionLog.getAction()), new Numeral(actionLog.getID()), parList) };
+		Stakeholder stakeholder = actionLog.getStakeholder();
+		return new Parameter[] { new Function("actionlog",
+				new Numeral(stakeholder.getID()),
+				new Identifier(actionLog.getAction()),
+				new Numeral(actionLog.getID()), parList) };
 	}
 
+	/**
+	 * Get the class which is translated from.
+	 */
 	@Override
 	public Class<? extends ActionLog> translatesFrom() {
 		return ActionLog.class;

--- a/environment/src/main/java/tygronenv/translators/J2ActionLog.java
+++ b/environment/src/main/java/tygronenv/translators/J2ActionLog.java
@@ -29,17 +29,13 @@ public class J2ActionLog implements Java2Parameter<ActionLog> {
 	 */
 	public J2ActionLog() {
 	}
-	
 	/**
 	 * Translates the actionlog into a parameter.
 	 */
 	@Override
 	public Parameter[] translate(final ActionLog actionLog) throws TranslationException {
-	    
 	    ParameterList parList = new ParameterList();
-	    ItemMap<Indicator> map =
-	    		EventManager.<Indicator>getItemMap(MapLink.INDICATORS);
-	    
+	    ItemMap<Indicator> map = EventManager.<Indicator>getItemMap(MapLink.INDICATORS);
 		for (Indicator indicator : map.values()) {
 			Double increase = actionLog.getIncrease(indicator);
 			if (increase != null && increase != 0.0) {
@@ -49,7 +45,7 @@ public class J2ActionLog implements Java2Parameter<ActionLog> {
 		}
 
 		Stakeholder stakeholder = actionLog.getStakeholder();
-		return new Parameter[] { new Function("actionlog",
+		return new Parameter[] {new Function("actionlog",
 				new Numeral(stakeholder.getID()),
 				new Identifier(actionLog.getAction()),
 				new Numeral(actionLog.getID()), parList) };

--- a/environment/src/test/java/tygronenv/TestEnvironment.java
+++ b/environment/src/test/java/tygronenv/TestEnvironment.java
@@ -65,7 +65,6 @@ public class TestEnvironment {
 	@Test
 	public void testGetStakeHolder() throws ManagementException {
 		Map<String, Parameter> parameters = new HashMap<String, Parameter>();
-		System.out.println(parameters.toString());
 		parameters.put(PROJECT, PROJECTNAME);
 		// parameters.put(STAKEHOLDER, new Identifier("MUNICIPALITY"));
 		parameters.put(STAKEHOLDERS, new ParameterList(new Identifier(MUNICIPALITY)));

--- a/environment/src/test/java/tygronenv/translators/J2ActionLogTest.java
+++ b/environment/src/test/java/tygronenv/translators/J2ActionLogTest.java
@@ -1,46 +1,208 @@
 package tygronenv.translators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.LinkedList;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import eis.eis2java.exception.TranslationException;
+import eis.iilang.Function;
+import eis.iilang.Identifier;
+import eis.iilang.Numeral;
+import eis.iilang.Parameter;
+import eis.iilang.ParameterList;
 import nl.tytech.core.client.event.EventManager;
 import nl.tytech.core.net.serializable.MapLink;
 import nl.tytech.core.structure.ItemMap;
 import nl.tytech.data.engine.item.ActionLog;
 import nl.tytech.data.engine.item.Indicator;
+import nl.tytech.data.engine.item.Stakeholder;
 
+/**
+ * Test class for the J2ActionLog class.
+ * @author Haoming
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({EventManager.class, ActionLog.class, Indicator.class})
 public class J2ActionLogTest {
 
+    /**
+     * Translator to be tested.
+     */
     private J2ActionLog translator;
+    
+    /**
+     * ActionLog to be translated.
+     */
     private ActionLog actionLog;
+    
+    /**
+     * Indicator to be checked for increase.
+     */
     private Indicator indicator;
     
+    /**
+     * Initialization method for the Test class.
+     * In this method mocks are created with PowerMockito for the dependencies.
+     * Also some of the required methods are stubbed in order for the tests to work.
+     */
+    @SuppressWarnings("unchecked")
     @Before
     public void init() {
         translator = new J2ActionLog();
-        actionLog = mock(ActionLog.class);
-        indicator = mock(Indicator.class);
-        ItemMap<Indicator> map = mock(ItemMap.class);
+        actionLog = PowerMockito.mock(ActionLog.class);
+        indicator = PowerMockito.mock(Indicator.class);
+        ItemMap<Indicator> map = (ItemMap<Indicator>) mock(ItemMap.class);
         LinkedList<Indicator> list = new LinkedList<Indicator>();
         list.add(indicator);
         when(map.values()).thenReturn(list);
-        EventManager man = mock(EventManager.class);
-        when(EventManager.<Indicator>getItemMap(MapLink.INDICATORS)).thenReturn(map);
+        PowerMockito.mockStatic(EventManager.class);
+        PowerMockito.when(EventManager.<Indicator>getItemMap(MapLink.INDICATORS)).thenReturn(map);
+        PowerMockito.when(actionLog.getID()).thenReturn(0);
+        PowerMockito.when(actionLog.getAction()).thenReturn("action");
+        Stakeholder stakeholder = PowerMockito.mock(Stakeholder.class);
+        PowerMockito.when(stakeholder.getID()).thenReturn(0);
+        PowerMockito.when(actionLog.getStakeholder()).thenReturn(stakeholder);
     }
     
+    /**
+     * Test method for translating ActionLog and only checking that the right 
+     * methods are called. Also check that the name of the function is correct.
+     * @throws TranslationException if translating goes wrong
+     */
     @Test
-    public void testTranslate() throws TranslationException {
-        translator.translate(actionLog);
+    public void testTranslateVerifyCalls() throws TranslationException {
+        Function function = (Function) translator.translate(actionLog)[0];
+        assertEquals(function.getName(), "actionlog");
         verify(actionLog).getAction();
         verify(actionLog).getIncrease(indicator);
         verify(actionLog).getStakeholder();
         verify(actionLog).getID();
+    }
+    
+    /**
+     * Test method for translating ActionLog without an increased indicator.
+     * Check that the Id is the same as expected.
+     * @throws TranslationException if translating goes wrong
+     */
+    @Test
+    public void testTranslateWithNoIncreasedIndicatorId() throws TranslationException {
+        when(actionLog.getIncrease(indicator)).thenReturn(0.0);
+        Function function = (Function) translator.translate(actionLog)[0];
+        for (Parameter p : function.getParameters()) {
+            if (p instanceof Numeral) {
+                assertEquals(((Numeral) p).getValue(), 0);
+            } 
+        }
+    }
+    
+    /**
+     * Test method for translating ActionLog without an increased indicator.
+     * Check that the identifier action is the same.
+     * @throws TranslationException if translating goes wrong
+     */
+    @Test
+    public void testTranslateWithNoIncreasedIndicatorIdentifier() throws TranslationException {
+        when(actionLog.getIncrease(indicator)).thenReturn(0.0);
+        Function function = (Function) translator.translate(actionLog)[0];
+        verify(actionLog).getAction();
+        verify(actionLog).getIncrease(indicator);
+        verify(actionLog).getStakeholder();
+        verify(actionLog).getID();
+        for (Parameter p : function.getParameters()) {
+            if(p instanceof Identifier) {
+                assertEquals(((Identifier)p).getValue(), "action");
+            } 
+        }
+    }
+    
+    
+    /**
+     * Test method for translating ActionLog without an increased indicator.
+     * Check that the list of increased/decreased indicators is empty.
+     * @throws TranslationException if translating goes wrong
+     */
+    @Test
+    public void testTranslateWithNoIncreasedIndicatorListEmpty() throws TranslationException {
+        when(actionLog.getIncrease(indicator)).thenReturn(0.0);
+        Function function = (Function) translator.translate(actionLog)[0];
+        verify(actionLog).getAction();
+        verify(actionLog).getIncrease(indicator);
+        verify(actionLog).getStakeholder();
+        verify(actionLog).getID();
+        for (Parameter p : function.getParameters()) {
+            if (p instanceof ParameterList) {
+                assertTrue(((ParameterList) p).isEmpty());
+            }
+        }
+    }
+    
+    /**
+     * Method to translate ActionLog with an increased indicator.
+     * Check that the list of increased indicators are not empty.
+     * @throws TranslationException if translating goes wrong
+     */
+    @Test
+    public void testTranslateWithIncreasedIndicatorNotEmptyList() throws TranslationException {
+        when(actionLog.getIncrease(indicator)).thenReturn(2.0);
+        Function function = (Function) translator.translate(actionLog)[0];
+        for (Parameter p : function.getParameters()) {
+            if (p instanceof ParameterList) {
+                assertFalse(((ParameterList) p).isEmpty());
+            }
+        }
+    }
+    
+    /**
+     * Method to translate ActionLog with an increased indicator.
+     * Check that the increased id of the increased indicator is correct.
+     * @throws TranslationException if translating goes wrong
+     */
+    @Test
+    public void testTranslateWithIncreasedIndicatorId() throws TranslationException {
+        when(actionLog.getIncrease(indicator)).thenReturn(2.0);
+        when(indicator.getID()).thenReturn(1);
+        Function function = (Function) translator.translate(actionLog)[0];
+        for (Parameter p : function.getParameters()) {
+            if (p instanceof ParameterList) {
+                for (Parameter par : (ParameterList) p) {
+                    Parameter indicatorId = ((ParameterList) par).get(0);
+                    assertEquals(((Numeral)indicatorId).getValue(), 1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to translate ActionLog with an increased indicator.
+     * Check that the increased value of the indicator is correct.
+     * @throws TranslationException if translating goes wrong
+     */
+    @Test
+    public void testTranslateWithIncreasedIndicatorValue() throws TranslationException {
+        when(actionLog.getIncrease(indicator)).thenReturn(2.0);
+        when(indicator.getID()).thenReturn(1);
+        Function function = (Function) translator.translate(actionLog)[0];
+        for (Parameter p : function.getParameters()) {
+            if (p instanceof ParameterList) {
+                for (Parameter par : (ParameterList) p) {
+                    Parameter increase = ((ParameterList) par).get(1);
+                    assertEquals(((Numeral)increase).getValue(), 2.0);
+                }
+            }
+        }
     }
 }

--- a/environment/src/test/java/tygronenv/translators/J2ActionLogTest.java
+++ b/environment/src/test/java/tygronenv/translators/J2ActionLogTest.java
@@ -1,0 +1,46 @@
+package tygronenv.translators;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import eis.eis2java.exception.TranslationException;
+import nl.tytech.core.client.event.EventManager;
+import nl.tytech.core.net.serializable.MapLink;
+import nl.tytech.core.structure.ItemMap;
+import nl.tytech.data.engine.item.ActionLog;
+import nl.tytech.data.engine.item.Indicator;
+
+public class J2ActionLogTest {
+
+    private J2ActionLog translator;
+    private ActionLog actionLog;
+    private Indicator indicator;
+    
+    @Before
+    public void init() {
+        translator = new J2ActionLog();
+        actionLog = mock(ActionLog.class);
+        indicator = mock(Indicator.class);
+        ItemMap<Indicator> map = mock(ItemMap.class);
+        LinkedList<Indicator> list = new LinkedList<Indicator>();
+        list.add(indicator);
+        when(map.values()).thenReturn(list);
+        EventManager man = mock(EventManager.class);
+        when(EventManager.<Indicator>getItemMap(MapLink.INDICATORS)).thenReturn(map);
+    }
+    
+    @Test
+    public void testTranslate() throws TranslationException {
+        translator.translate(actionLog);
+        verify(actionLog).getAction();
+        verify(actionLog).getIncrease(indicator);
+        verify(actionLog).getStakeholder();
+        verify(actionLog).getID();
+    }
+}


### PR DESCRIPTION
Fixes #52 and added PowerMockito for testing.

actionlog(`<StakeholderID>`, `<actionDescription>`, `<actionID>`, [[`<indicatorID>`, `<indicatorIncrease>`], ..]) 
Only puts an indicator and its increase in the list if the increase is not equal to 0,0.
Danshal
