### PR TITLE
Checkstyle prohibit space indentation.

### DIFF
--- a/sun_checks_custom.xml
+++ b/sun_checks_custom.xml
@@ -74,6 +74,14 @@
        <property name="message" value="Line has trailing spaces."/>
     </module>
 
+	<!-- Checks for lines with space indentation			-->
+	<!-- Space indentation should not be used as the entire	-->
+	<!-- existing project uses tab indentation.				-->
+	<module name="RegexpSingleline">
+		<property name="format" value="^[ ]{2,}"/>
+		<property name="message" value="Too many leading spaces."/>
+	</module>
+
     <!-- Checks for Headers                                -->
     <!-- See http://checkstyle.sf.net/config_header.html   -->
     <!-- <module name="Header"> -->

--- a/sun_checks_custom.xml
+++ b/sun_checks_custom.xml
@@ -74,9 +74,9 @@
        <property name="message" value="Line has trailing spaces."/>
     </module>
 
-	<!-- Checks for lines with space indentation			-->
-	<!-- Space indentation should not be used as the entire	-->
-	<!-- existing project uses tab indentation.				-->
+	<!-- Checks for lines with space indentation            -->
+	<!-- Space indentation should not be used as the entire -->
+	<!-- existing project uses tab indentation.             -->
 	<module name="RegexpSingleline">
 		<property name="format" value="^[ ]{2,}"/>
 		<property name="message" value="Too many leading spaces."/>


### PR DESCRIPTION
Added a check to checkstyle that prohibits the use of space indentation.
Right now we have disabled the check that prohibits tab indentation, but there was no check for space indentation. Apparently that means people think they can use space indentation, but the point of checkstyle is that all code is styled in the same way.
This pull request adds a check for space indentation, so all of the code will still be styled in the same way.

User story:
As a developer, I want my source code to be readable and consistent, so it is easier to read, understand and edit.
