### PR TITLE
Fix bugs in getRelevantAreas

### DIFF
--- a/contextvh/src/main/java/contextvh/actions/GetRelevantAreasBuild.java
+++ b/contextvh/src/main/java/contextvh/actions/GetRelevantAreasBuild.java
@@ -26,7 +26,7 @@ import nl.tytech.util.logger.TLogger;
  */
 public class GetRelevantAreasBuild implements RelevantAreasAction {
 
-	private static GetRelevantAreas parent;
+	private GetRelevantAreas parent;
 
 	/**
 	 * Create a new <code>GetRelevantAreasBuild</code> action.

--- a/contextvh/src/main/java/contextvh/util/MapUtils.java
+++ b/contextvh/src/main/java/contextvh/util/MapUtils.java
@@ -74,7 +74,7 @@ public final class MapUtils {
 		MultiPolygon result = JTSUtils.EMPTY;
 		final ItemMap<Land> lands = EventManager.getItemMap(connectionID, MapLink.LANDS);
 		for (Land land : lands) {
-			if (land.getOwnerID() == stakeholderID) {
+			if (land.getOwnerID().equals(stakeholderID)) {
 				result = JTSUtils.union(result, land.getMultiPolygon());
 			}
 		}


### PR DESCRIPTION
The parent variable in getRelevantAreasBuild should not be static and a comparison between objects should ofcourse use the equals function.

Travis: https://travis-ci.org/Denpeer/tygron/builds/136528156
