### PR TITLE
MapUtils performance fix

### DIFF
--- a/contextvh/src/main/java/contextvh/actions/GetRelevantAreasBuild.java
+++ b/contextvh/src/main/java/contextvh/actions/GetRelevantAreasBuild.java
@@ -110,7 +110,7 @@ public class GetRelevantAreasBuild implements RelevantAreasAction {
 		constructableLand = MapUtils.removeReservedLand(connectionID, constructableLand);
 
 		// Remove all pieces of occupied land.
-		constructableLand = MapUtils.removeBuildings(connectionID, constructableLand);
+		constructableLand = MapUtils.removeBuildings(connectionID, stakeholderID, constructableLand);
 
 		return constructableLand;
 	}

--- a/contextvh/src/main/java/contextvh/util/MapUtils.java
+++ b/contextvh/src/main/java/contextvh/util/MapUtils.java
@@ -21,6 +21,7 @@ import nl.tytech.util.JTSUtils;
 
 /**
  * Utility class for performing often used operations on map elements.
+ *
  * @author Max Groenenboom
  */
 public final class MapUtils {
@@ -34,10 +35,15 @@ public final class MapUtils {
 	protected static final MapType DEFAULT_MAPTYPE = MapType.MAQUETTE;
 
 	/**
-	 * Returns a Geometry of all zones with its ID in ids combined, if an empty list or no ids are given,
-	 * a Geometry containing all zones will be returned.
-	 * @param connectionID The id of the connection.
-	 * @param ids The list of zone ID's. If the list is empty, all zones will be used.
+	 * Returns a Geometry of all zones with its ID in ids combined, if an empty
+	 * list or no ids are given, a Geometry containing all zones will be
+	 * returned.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param ids
+	 *            The list of zone ID's. If the list is empty, all zones will be
+	 *            used.
 	 * @return The resulting Geometry.
 	 */
 	public static Geometry getZonesCombined(final Integer connectionID, final List<Integer> ids) {
@@ -53,10 +59,15 @@ public final class MapUtils {
 	}
 
 	/**
-	 * Returns a Geometry of all zones with its ID in ids combined, if an empty list or no ids are given,
-	 * a Geometry containing all zones will be returned.
-	 * @param connectionID The id of the connection.
-	 * @param ids The list of zone ID's. If the list is empty, all zones will be used.
+	 * Returns a Geometry of all zones with its ID in ids combined, if an empty
+	 * list or no ids are given, a Geometry containing all zones will be
+	 * returned.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param ids
+	 *            The list of zone ID's. If the list is empty, all zones will be
+	 *            used.
 	 * @return The resulting Geometry.
 	 */
 	public static Geometry getZonesCombined(final Integer connectionID, final Integer... ids) {
@@ -66,8 +77,11 @@ public final class MapUtils {
 
 	/**
 	 * Returns a Geometry of all land of the stakeholder with ID stakeholderID.
-	 * @param connectionID The id of the connection.
-	 * @param stakeholderID The ID of the stakeholder.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param stakeholderID
+	 *            The ID of the stakeholder.
 	 * @return The resulting Geometry.
 	 */
 	public static MultiPolygon getStakeholderLands(final Integer connectionID, final Integer stakeholderID) {
@@ -83,8 +97,11 @@ public final class MapUtils {
 
 	/**
 	 * Removes all water from the multiPolygon mp.
-	 * @param connectionID The id of the connection.
-	 * @param mp The MultiPolygon to perform the operation on.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param mp
+	 *            The MultiPolygon to perform the operation on.
 	 * @return The MultiPolygon without all water.
 	 */
 	public static MultiPolygon removeWater(final Integer connectionID, final MultiPolygon mp) {
@@ -93,8 +110,11 @@ public final class MapUtils {
 
 	/**
 	 * Removes all land from the multiPolygon mp.
-	 * @param mp The MultiPolygon to perform the operation on.
-	 * @param connectionID The id of the connection.
+	 *
+	 * @param mp
+	 *            The MultiPolygon to perform the operation on.
+	 * @param connectionID
+	 *            The id of the connection.
 	 * @return The MultiPolygon without all land.
 	 */
 	public static MultiPolygon removeLand(final Integer connectionID, final MultiPolygon mp) {
@@ -103,13 +123,17 @@ public final class MapUtils {
 
 	/**
 	 * Removes all water or land from the multiPolygon mp.
-	 * @param connectionID The id of the connection.
-	 * @param mp The MultiPolygon to perform the operation on.
-	 * @param removeWater Toggles whether water or land will be removed.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param mp
+	 *            The MultiPolygon to perform the operation on.
+	 * @param removeWater
+	 *            Toggles whether water or land will be removed.
 	 * @return The MultiPolygon without all water or land.
 	 */
-	private static MultiPolygon removeWaterOrLand(final Integer connectionID,
-			final MultiPolygon mp, final boolean removeWater) {
+	private static MultiPolygon removeWaterOrLand(final Integer connectionID, final MultiPolygon mp,
+			final boolean removeWater) {
 		final ItemMap<Terrain> terrains = EventManager.getItemMap(connectionID, MapLink.TERRAINS);
 		MultiPolygon mpResult = mp;
 		for (Terrain terrain : terrains) {
@@ -122,14 +146,16 @@ public final class MapUtils {
 
 	/**
 	 * Removes all reserved land from the MultiPolygon mp.
-	 * @param connectionID The id of the connection.
-	 * @param mp The MultiPolygon to perform the operation on.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param mp
+	 *            The MultiPolygon to perform the operation on.
 	 * @return The MultiPolygon without all reserved land.
 	 */
-	public static MultiPolygon removeReservedLand(final Integer connectionID,
-			final MultiPolygon mp) {
-		final Setting reservedLandSetting = EventManager.getItem(connectionID,
-				MapLink.SETTINGS, Setting.Type.RESERVED_LAND);
+	public static MultiPolygon removeReservedLand(final Integer connectionID, final MultiPolygon mp) {
+		final Setting reservedLandSetting = EventManager.getItem(connectionID, MapLink.SETTINGS,
+				Setting.Type.RESERVED_LAND);
 		MultiPolygon reservedLand = reservedLandSetting.getMultiPolygon();
 		MultiPolygon mpResult = mp;
 		if (JTSUtils.containsData(reservedLand)) {
@@ -139,18 +165,28 @@ public final class MapUtils {
 	}
 
 	/**
-	 * Remove all buildings from a given multipolygon.
-	 * @param connectionID The id of the connection.
-	 * @param mp The multipolygon where buildings need to be removed.
-	 * @return A multipolygon with all buildings removed.
+	 * Remove all buildings' areas from a given multipolygon.
+	 *
+	 * @param connectionID
+	 *            The id of the connection.
+	 * @param stakeHolderID
+	 *            The id of the stakeholder whose buildings' areas have to be
+	 *            removed. Removes all buildings' areas if it is null.
+	 * @param mp
+	 *            The multipolygon where buildings' areas need to be removed.
+	 * @return A multipolygon with all buildings' areas removed.
 	 */
-	public static MultiPolygon removeBuildings(final Integer connectionID, final MultiPolygon mp) {
+	public static MultiPolygon removeBuildings(final Integer connectionID, final Integer stakeHolderID,
+			final MultiPolygon mp) {
 		final ItemMap<Building> buildings = EventManager.getItemMap(connectionID, MapLink.BUILDINGS);
 		MultiPolygon constructableLand = mp;
 		final PreparedGeometry prepped = PreparedGeometryFactory.prepare(constructableLand);
 		for (Building building : buildings) {
 			final MultiPolygon buildingMP = building.getMultiPolygon(DEFAULT_MAPTYPE);
-			if (prepped.intersects(buildingMP)) {
+			// Only remove areas of buildings that are owned by the given
+			// stakeholder, or all if it is null.
+			if ((stakeHolderID == null || building.getOwner().getID().equals(stakeHolderID))
+					&& prepped.intersects(buildingMP)) {
 				constructableLand = JTSUtils.difference(constructableLand, buildingMP);
 			}
 		}

--- a/contextvh/src/test/java/contextvh/util/MapUtilsTest.java
+++ b/contextvh/src/test/java/contextvh/util/MapUtilsTest.java
@@ -243,7 +243,7 @@ public class MapUtilsTest {
 		joinAsMunicipality();
 		Geometry geo = MapUtils.getZonesCombined(connectionID, ZONE_WITH_BUILDING);
 		MultiPolygon mp = JTSUtils.createMP(geo);
-		mp = MapUtils.removeBuildings(connectionID, mp);
+		mp = MapUtils.removeBuildings(connectionID, null, mp);
 		final int areaBuilding = 4;
 		assertEquals(AREA_MUNICIPALITY / NUM_ZONES - areaBuilding, mp.getArea(), 0);
 	}


### PR DESCRIPTION
It is now possible to only remove buildings' areas for buildings that are owned by a certain stakeholder. This value can also be null to still filter on all stakeholders' buildings' areas.

This enhancement speeds the get_relevant_areas(_,build,_) action up to more than twice the speed. (from 14 seconds to 6 seconds). The action already takes only the current stakeholder's lands, so filtering on all buildings is redundant. This PR improves this behavior by first checking if a building is owned by the player, before attempting to intersect it with the remaining land. Of course the performance gain depends on how many buildings a stakeholder owns, but for some stakeholders the gain will be significant.

Travis: [![Build Status](https://travis-ci.org/Denpeer/tygron.svg?branch=filter_own_buildings)](https://travis-ci.org/Denpeer/tygron)
